### PR TITLE
[feature/gcafs] feat: remove fortran line length restrictions for all GNU build types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,17 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-sanitize=all")
 endif()
 
+# No Fortran line length restrictions on all GNU build types
+if(
+  CMAKE_Fortran_COMPILER_ID MATCHES "GNU|G95"
+)
+  list(
+  APPEND
+  _catchem_compiler_options
+  -ffree-line-length-none
+  )
+endif()
+
 if(
   CMAKE_Fortran_COMPILER_ID MATCHES "GNU|G95"
   AND CMAKE_BUILD_TYPE MATCHES "Debug"
@@ -69,7 +80,6 @@ if(
     -ffpe-trap=invalid,zero,overflow
     -fbacktrace
     -fmax-errors=0
-    -ffree-line-length-none
   )
 elseif(
   CMAKE_Fortran_COMPILER_ID MATCHES "Intel"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,14 +55,8 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
 endif()
 
 # No Fortran line length restrictions on all GNU build types
-if(
-  CMAKE_Fortran_COMPILER_ID MATCHES "GNU|G95"
-)
-  list(
-  APPEND
-  _catchem_compiler_options
-  -ffree-line-length-none
-  )
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU|G95")
+  list(APPEND _catchem_compiler_options -ffree-line-length-none)
 endif()
 
 if(


### PR DESCRIPTION
closes #156